### PR TITLE
Fix crash due to unexpected tsc compilation of referenced source code.

### DIFF
--- a/plugin/compile-tsc.js
+++ b/plugin/compile-tsc.js
@@ -155,10 +155,12 @@ function compile(arch, placeholderCompileStep, hadModifications) {
 			// result.name is the theoretically-generated js filename
 			var tsFullPath = result.name.substr(0, result.name.length - 2) + "ts";
 			var compileStep = arch.fullPathToCompileSteps[tsFullPath];
-			var src = processGenSource(result.src || "");
-			var map = result.map || "";
-			// store in file cache
-			storage.setItem(b64encode(compileStep.fullInputPath), [src, map]);
+			if (compileStep) {
+				var src = processGenSource(result.src || "");
+				var map = result.map || "";
+				// store in file cache
+				storage.setItem(b64encode(compileStep.fullInputPath), [src, map]);
+			}
 		});
 	});
 


### PR DESCRIPTION
tsc compiles referenced files it sees at the top of the documents we
compile, even if we don't ask for that explicitly. To exemplify, if
main.ts contains this at its top

   /// &lt;reference path="./game/GameService.ts"/>.

Then tsc will compile GameService.ts as well and return those results.
This causes buggy behavior when Meteor on Windows splits compilation of
the server directory into multiple calls, splicing zzz.ts-compiler into
the mix seemingly randomly.