### PR TITLE
Fix for issue #25

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ See [http://www.typescriptlang.org](http://www.typescriptlang.org) for more info
 
 * Run `npm install -g typescript`, you must be running version 1.4*
 
-* If on Windows, please install the Visual Studio plugin instead of using NPM. All versions are supported through this method.
+* **If on Windows, please install the Visual Studio plugin instead of using NPM. All versions are supported through this method.**
 
 * From your Meteor project, type `meteor add meteortypescript:compiler`
 
@@ -37,7 +37,8 @@ That's it! From now on, all `*.ts` files are dynamically compiled into Javascrip
 * The code is based from the Meteor coffeescript package.
 
 ## Updates
-* **Jul 8 2015** - fixed an issue where tsc could not be found on Windows (must install TypeScript for Visual Studio).
+* **Jul 8 2015** - fixed an issue on Windows where zzz.ts-compiler.ts would try and make itself on the C:\ drive if your project was located in My Documents. - Jacob Foster
+* **Jul 8 2015** - fixed an issue where tsc could not be found on Windows (must install TypeScript for Visual Studio) - Jacob Foster
 * **Feb 22 2015** - support for source maps. comments are now removed from generated files.
 * **Feb 17 2015** - typescrypt-compiler v2, batch compilation using tsc - code merged from meteor-tsc, thanks to jason parekh.
 * **Oct 26 2014** - Upgraded package to latest atmosphere, fixed issues with caching.

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
 	name: "meteortypescript:compiler",
 	summary: "TypeScript is a staticaly typed superset of JavaScript",
 	git: "https://github.com/meteor-typescript/meteor-typescript-compiler.git",
-	version: "2.0.8"
+	version: "2.0.10"
 });
 
 Package._transitional_registerBuildPlugin({

--- a/plugin/compile-tsc.js
+++ b/plugin/compile-tsc.js
@@ -276,6 +276,11 @@ function resetCompilationScopedArch(arch) {
 function checkForPlaceholderFile(compileStep) {
 	// Either curPath should be e.g. zzz.ts-compiler.ts or packages/myPkg/zzz.ts-compiler.ts
 	var curPath = (!compileStep || compileStep.rootOutputPath == '/') ? PLACEHOLDER_FILENAME : compileStep.rootOutputPath.substr(1) + "/" + PLACEHOLDER_FILENAME;
+	
+	// Check and see if we are trying to create the placeholder file in the root directory, if we are, then switch over to the fullInputPath that we
+	// receive from the compileStep object.
+	if (compileStep && curPath === '/zzz.ts-compiler.ts') curPath = compileStep.fullInputPath;
+	
 	if (!fs.existsSync(curPath)) {
 		fs.writeFileSync(curPath, "// please add this file to .gitignore - it is used internally by typescript-compiler and must be the last file to compile\n// This needs some real logic so that tsc will use this dir as the starting path for all produced output\nif (true) {}\n");
 		var errorMsg = "typescript-compiler:The file \"" + curPath + "\" has been created to help batch compilation of typescript assets. Please ignore it from your source control.";


### PR DESCRIPTION
- Fixed an issue where the placeholder file would try to create on the C:\ drive if the project was in the Documents folder on Windows.

Fixes the issue mentioned [here](https://github.com/meteor-typescript/meteor-typescript-compiler/issues/25).