### PR TITLE
Workaround to use non-global, project local version of tsc binary

### DIFF
--- a/plugin/compile-tsc.js
+++ b/plugin/compile-tsc.js
@@ -43,7 +43,9 @@ var tscPath = function() {
 	var bins = glob.sync("~/.meteor/packages/*:tsc/*/plugin.compileTsc.os/npm/compileTsc/node_modules/typescript/bin/tsc").concat(
 		glob.sync("packages/*:tsc/.npm/plugin/compileTsc/node_modules/typescript/bin/tsc"),
 		glob.sync("C:/Program Files (x86)/Microsoft SDKs/TypeScript/**/tsc.exe"),
-		glob.sync("/usr/local/bin/tsc"));
+		glob.sync("/usr/local/bin/tsc"),
+        glob.sync(process.env.PWD + "/**/node_modules/typescript/bin/tsc", {dot:true}) 
+    );
 	if (bins.length === 0) {
 		console.error("Could not find tsc binary, defaulting to 'tsc'.")
 		return "tsc";


### PR DESCRIPTION
Modified the glob search to check the project root directory (using process.env.PWD) for a tsc binary before moving on to the system default on the $PATH. Change also modifies the `glob` package treatment of dotfiles to make the expansion more robust.

The fix feels a little bit hacky -- and the glob expansion actually ends up having more than one match -- but it nonetheless seems to work for now. 

Addresses the issue raised in #21 